### PR TITLE
add citation information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Demo: Racoon image
 - Include examples in pytest bench
 - Include demos in pytest bench
+- Citation information via CITATION.cff
   
 ### Changed
 - Fix internal TODOs to improve code quality

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+authors: 
+  -
+    affiliation: "Merck KGaA, Darmstadt, Germany"
+    family-names: Šošić
+    given-names: Adrian
+    orcid: https://orcid.org/0000-0003-2845-6635
+  -
+    affiliation: "Merck KGaA, Darmstadt, Germany"
+    family-names: Winkel
+    given-names: Mathias
+    orcid: https://orcid.org/0000-0002-0345-9701
+license: "Apache-2.0"
+message: "If you use this software, please cite it using these metadata."
+url: "https://emdgroup.github.io/tnmf/"
+repository-code: "https://github.com/emdgroup/tnmf"
+title: "Transform-Invariant Non-Negative Matrix Factorization"
+date-released: 2021-07-12
+

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 
 [![Logo](https://raw.githubusercontent.com/emdgroup/tnmf/main/logos/tnmf_header.svg)](https://github.com/emdgroup/tnmf)
 
-# Transform-Invariant Non-Negative Matrix Factorization
+Transform-Invariant Non-Negative Matrix Factorization
+=====================================================
 
 A comprehensive Python package for **Non-Negative Matrix Factorization (NMF)** with a focus on learning *transform-invariant representations*.
 
@@ -25,7 +26,6 @@ Installation is easiest using pip:
     pip install tnmf
 
 # Demos and Examples
-
 The package comes with a [streamlit](https://streamlit.io) demo and a number of examples that demonstrate the capabilities of the TNMF model.
 They provide a good starting point for your own experiments.
 
@@ -55,6 +55,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 The full text of the license can be found in the file [LICENSE](LICENSE) in the repository root directory.
+
+# Usage and Citation
+If you use this software, please cite us using the information in CITATION.cff.
 
 # Contributing
 Contributions to the package are always welcome and can be submitted via a pull request.


### PR DESCRIPTION
fixes #57 

This yields the following citation support to the GitHub web front-end:

<img width="451" alt="image" src="https://user-images.githubusercontent.com/5322274/137721193-5a1ad98f-3943-44af-8a17-9d65d5e7e750.png">
